### PR TITLE
Add MYPROJECT placeholder to more instances

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
-baseURL = "https://axway-open-docs.netlify.com/"
-title = "Axway-Open-Docs"
+baseURL = "https://MYPROJECT-open-docs.netlify.com/"
+title = "MYPROJECT-Open-Docs"
 
 enableRobotsTXT = true
 
@@ -81,7 +81,7 @@ privacy_policy = "https://www.axway.com/en/privacy-statement"
 version_menu = "Releases"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/Axway/axway-open-docs"
+github_repo = "https://github.com/Axway/MYPROJECT-open-docs"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 # github_project_repo = "https://github.com/google/docsy"
 
@@ -114,8 +114,8 @@ footer_about_disable = true
 [params.ui.feedback]
 enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-yes = 'Glad to hear it! Please <a href="https://github.com/Axway/axway-open-docs/issues/new">tell us how we can improve</a>.'
-no = 'Sorry to hear that. Please <a href="https://github.com/Axway/axway-open-docs/issues/new">tell us how we can improve</a>.'
+yes = 'Glad to hear it! Please <a href="https://github.com/Axway/MYPROJECT-open-docs/issues/new">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/Axway/MYPROJECT-open-docs/issues/new">tell us how we can improve</a>.'
 
 # Adds a reading time to the top of each doc.
 # If you want this feature, but occasionally need to remove the Reading time from a single page, 
@@ -143,9 +143,9 @@ enable = true
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
 	name = "GitHub"
-	url = "https://github.com/Axway/axway-open-docs"
+	url = "https://github.com/Axway/MYPROJECT-open-docs"
 	icon = "fab fa-github"
-        desc = "Axway-Open-Docs project on GitHub"
+        desc = "MYPROJECT-Open-Docs project on GitHub"
 [[params.links.developer]]
 	name = "Axway Developer Portal"
 	url = "https://developer.axway.com/"


### PR DESCRIPTION
@alexearnshaw, after following section [Update the Netlify CMS configuration for your repository and microsite](https://github.com/Axway/open-docs-microsite-template#update-the-netlify-cms-configuration-for-your-repository-and-microsite), I still could see `axway-open-docs` on `amplifystreams` Netlify CMS.  

![streams_cms](https://user-images.githubusercontent.com/10401080/89534193-772e5400-d7ec-11ea-8390-047cbc701562.png)

So, I'm updating the `config.toml` and replacing all `axway-` ocurrences with `MYPROJECT` at once. I don't think this will cause any issue to any other steps in the readme ??

![streams_cms2](https://user-images.githubusercontent.com/10401080/89534396-beb4e000-d7ec-11ea-9a03-e8dcd9bdf91d.png)


