### PR TITLE
RMF-177 Update yargs-parser and postcss to a non-vulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,7 @@
         "colorette": "^1.2.0",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.32",
+        "postcss": "^8.2.10",
         "postcss-value-parser": "^4.1.0"
       }
     },
@@ -2158,8 +2158,8 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+      "version": "8.2.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
       "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
       "dev": true,
       "requires": {
@@ -2982,12 +2982,12 @@
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "yargs-parser": "^13.1.2"
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
RMF-177 Update yargs-parser and postcss to a non-vulnerable version